### PR TITLE
Add https://www.kernel.org/pub to the list of mirrors.

### DIFF
--- a/scripts/download.pl
+++ b/scripts/download.pl
@@ -177,6 +177,7 @@ foreach my $mirror (@ARGV) {
 			push @extra, "$extra[0]/longterm/v$1";
 		}		
 		foreach my $dir (@extra) {
+			push @mirrors, "https://www.kernel.org/pub/$dir";
 			push @mirrors, "ftp://ftp.all.kernel.org/pub/$dir";
 			push @mirrors, "http://ftp.all.kernel.org/pub/$dir";
 		}


### PR DESCRIPTION
Recently, it was announced that kernel.org will shutdown their FTP
servers: https://kernel.org/shutting-down-ftp-services.html

In fact, the FTP server that hosts kernel sources went offline today.
That caused downloads to fail, and it has become impossible to build
the VoCore2 OpenWRT image.

This change adds the new HTTPS mirror that is here to stay.